### PR TITLE
Add Playwright PDF regression test

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,9 +9,12 @@ phases:
     commands:
       - npm install yarn --location=global
       - yarn install
+      - npx playwright install --with-deps
 
   build:
     commands:
       - yarn lint
       - cd packages/api
       - make all
+      - cd ..
+      - yarn test

--- a/package.json
+++ b/package.json
@@ -13,14 +13,16 @@
     "preversion": "git diff --exit-code",
     "release": "lerna version -m 'Release. Bump version number %v' --tag-version-prefix='' --force-publish",
     "deploy:stage": "lerna run deploy:stage --stream",
-    "deploy:prod": "lerna run deploy:prod --stream"
+    "deploy:prod": "lerna run deploy:prod --stream",
+    "test": "playwright test"
   },
   "devDependencies": {
     "jshint": "^2.13.6",
     "lerna": "^6.6.2",
     "serverless-apigw-binary": "^0.4.4",
     "serverless-webpack": "^5.5.0",
-    "webpack": "^5.11.1"
+    "webpack": "^5.11.1",
+    "@playwright/test": "^1.43.1"
   },
   "license": "MIT",
   "private": true

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,14 @@
+// @ts-check
+const { devices } = require('@playwright/test');
+
+/** @type {import('@playwright/test').PlaywrightTestConfig} */
+const config = {
+  webServer: {
+    command: 'node tests/server.js',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
+  testDir: './tests',
+};
+
+module.exports = config;

--- a/tests/golden.pdf
+++ b/tests/golden.pdf
@@ -1,0 +1,1 @@
+dummy pdf

--- a/tests/pdf.spec.js
+++ b/tests/pdf.spec.js
@@ -1,0 +1,22 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const crypto = require('crypto');
+
+const goldenPath = __dirname + '/golden.pdf';
+const goldenHash = 'eb17976537bbb06785a084c68709478012a90baefdf89284b9e6759a30caf397';
+
+function sha256(buffer) {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+test('generate pdf matches golden', async ({ request }) => {
+  const html = fs.readFileSync(__dirname + '/sample.html', 'utf8');
+  const response = await request.post('http://localhost:3000/print', {
+    data: { html }
+  });
+  expect(response.ok()).toBeTruthy();
+  const buffer = await response.body();
+  fs.writeFileSync(__dirname + '/out.pdf', buffer);
+  const hash = sha256(buffer);
+  expect(hash).toBe(goldenHash);
+});

--- a/tests/sample.html
+++ b/tests/sample.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Sample</title>
+</head>
+<body>
+  <h1>Hello World</h1>
+  <p>This is a sample document.</p>
+</body>
+</html>

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,0 +1,39 @@
+const http = require('http');
+const {handler} = require('../packages/api/print/print');
+
+function lambdaEvent(data) {
+  return {
+    body: Buffer.from(JSON.stringify(data)).toString('base64'),
+    isBase64Encoded: true
+  };
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/print') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      const data = JSON.parse(body);
+      const event = lambdaEvent(data);
+      handler(event, {}, (err, response) => {
+        if (err) {
+          res.statusCode = 500;
+          res.end(String(err));
+        } else {
+          res.writeHead(response.statusCode || 200, response.headers || {});
+          const buf = response.isBase64Encoded ? Buffer.from(response.body, 'base64') : Buffer.from(response.body);
+          res.end(buf);
+        }
+      });
+    });
+  } else {
+    res.statusCode = 404;
+    res.end('not found');
+  }
+});
+
+if (require.main === module) {
+  server.listen(3000, () => console.log('Server listening on 3000'));
+}
+
+module.exports = server;


### PR DESCRIPTION
## Summary
- add Playwright as a dev dependency
- create sample HTML and placeholder golden PDF
- implement a Playwright test that posts the HTML to a local server
- spin up the lambda handler via a small http server during tests
- run Playwright in CI via buildspec

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_682b639ed4e88326aa118e2988b98e71